### PR TITLE
Adding bailoutWhenEmpty, enabling AIMultiDelegate to be safe

### DIFF
--- a/MultiDelegate/AIMultiDelegate.h
+++ b/MultiDelegate/AIMultiDelegate.h
@@ -7,6 +7,11 @@
 
 @property (readonly, nonatomic) NSArray* delegates;
 
+/**
+ @discussion if set to YES, AIMultiDelegate will do nothing when a method is called on it but it has no delegates
+ */
+@property (nonatomic, assign) BOOL bailoutWhenEmpty;
+
 - (id)initWithDelegates:(NSArray*)delegates;
 
 - (void)addDelegate:(id)delegate;

--- a/MultiDelegate/AIMultiDelegate.m
+++ b/MultiDelegate/AIMultiDelegate.m
@@ -74,6 +74,10 @@
         if (signature)
             break;
     }
+    if (self.bailoutWhenEmpty && _delegates.count == 0) {
+        //just return any methodSignature, it doesn't really matter
+        return [self methodSignatureForSelector:@selector(description)];
+    }
     
     return signature;
 }
@@ -89,7 +93,7 @@
         }
     }
     
-    if (!responded)
+    if (!responded && !self.bailoutWhenEmpty)
         [self doesNotRecognizeSelector:selector];
 }
 


### PR DESCRIPTION
... when it has no delegates in it (as if we were calling a nil delegate).
