### PR TITLE
Fix crash

### DIFF
--- a/MultiDelegate/AIMultiDelegate.m
+++ b/MultiDelegate/AIMultiDelegate.m
@@ -69,7 +69,8 @@
     if ([super respondsToSelector:selector])
         return YES;
     
-    for (id delegate in _delegates) {
+    NSArray *copiedDelegates = [_delegates copy];
+    for (id delegate in copiedDelegates) {
         if (delegate && [delegate respondsToSelector:selector])
             return YES;
     }
@@ -88,7 +89,8 @@
         return [self methodSignatureForSelector:@selector(description)];
     }
     
-    for (id delegate in _delegates) {
+    NSArray *copiedDelegates = [_delegates copy];
+    for (id delegate in copiedDelegates) {
         if (!delegate)
             continue;
 
@@ -104,7 +106,8 @@
     SEL selector = [invocation selector];
     BOOL responded = NO;
     
-    for (id delegate in _delegates) {
+    NSArray *copiedDelegates = [_delegates copy];
+    for (id delegate in copiedDelegates) {
         if (delegate && [delegate respondsToSelector:selector]) {
             [invocation invokeWithTarget:delegate];
             responded = YES;


### PR DESCRIPTION
Iterate delegates using its copy to prevent possible crash if the delegates array is modified during iteration.
